### PR TITLE
fix build errors from electron

### DIFF
--- a/.changeset/friendly-candles-fix.md
+++ b/.changeset/friendly-candles-fix.md
@@ -1,0 +1,5 @@
+---
+'@irsdk-node/native': patch
+---
+
+fix build errors for electron forge

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ out
 
 # Dependencies
 node_modules
+
+# Coverage
+coverage

--- a/.yarn/versions/b497afed.yml
+++ b/.yarn/versions/b497afed.yml
@@ -1,0 +1,2 @@
+releases:
+  "@irsdk-node/workspace": 4.0.1

--- a/packages/irsdk-node-native/lib/irsdk_utils.cpp
+++ b/packages/irsdk-node-native/lib/irsdk_utils.cpp
@@ -338,7 +338,7 @@ unsigned int irsdk_getBroadcastMsgID()
 
 void irsdk_broadcastMsg(irsdk_BroadcastMsg msg, int var1, int var2, int var3)
 {
-	irsdk_broadcastMsg(msg, var1, MAKELONG(var2, var3));
+	irsdk_broadcastMsg(msg, var1, static_cast<int>MAKELONG(var2, var3));
 }
 
 void irsdk_broadcastMsg(irsdk_BroadcastMsg msg, int var1, float var2)

--- a/packages/irsdk-node-native/src/irsdk_node.h
+++ b/packages/irsdk-node-native/src/irsdk_node.h
@@ -32,12 +32,12 @@ private:
     Napi::Value __GetTelemetryTypes(const Napi::CallbackInfo &info);
     Napi::Value GetTelemetryVar(const Napi::CallbackInfo &info);
 
-    bool iRacingSdkNode::GetTelemetryBool(int entry, int index);
-    int iRacingSdkNode::GetTelemetryInt(int entry, int index);
-    float iRacingSdkNode::GetTelemetryFloat(int entry, int index);
-    double iRacingSdkNode::GetTelemetryDouble(int entry, int index);
-    Napi::Object iRacingSdkNode::GetTelemetryVarByIndex(const Napi::Env env, int index);
-    Napi::Object iRacingSdkNode::GetTelemetryVar(const Napi::Env env, const char *varName);
+    bool GetTelemetryBool(int entry, int index);
+    int GetTelemetryInt(int entry, int index);
+    float GetTelemetryFloat(int entry, int index);
+    double GetTelemetryDouble(int entry, int index);
+    Napi::Object GetTelemetryVarByIndex(const Napi::Env env, int index);
+    Napi::Object GetTelemetryVar(const Napi::Env env, const char *varName);
 
     bool _loggingEnabled;
     char* _data;


### PR DESCRIPTION
When build the library with electron forge I am getting two compile errors. For the change in irsdk_broadcastMsg
```
\node_modules\@irsdk-node\native\lib\irsdk_utils.cpp(341,2): error     
C2668: 'irsdk_broadcastMsg': ambiguous call to overloaded function
```
This is due to multiple overrides for that function, it needed to be explicitly casted.

Then I got additional errors due to the namespace not needed here:
```
\node_modules\@irsdk-node\native\src\irsdk_node.h(35,26): error        
C4596: 'GetTelemetryBool': illegal qualified name in member declaration
[\node_modules\@irsdk-node\native\build\irsdk_node.vcxproj]
\node_modules\@irsdk-node\native\src\irsdk_node.h(36,25): error        
C4596: 'GetTelemetryInt': illegal qualified name in member declaration
[\node_modules\@irsdk-node\native\build\irsdk_node.vcxproj]
\node_modules\@irsdk-node\native\src\irsdk_node.h(37,27): error        
C4596: 'GetTelemetryFloat': illegal qualified name in member declaration
[\node_modules\@irsdk-node\native\build\irsdk_node.vcxproj]
\node_modules\@irsdk-node\native\src\irsdk_node.h(38,28): error        
C4596: 'GetTelemetryDouble': illegal qualified name in member declaration
[\node_modules\@irsdk-node\native\build\irsdk_node.vcxproj]
\node_modules\@irsdk-node\native\src\irsdk_node.h(39,34): error        
C4596: 'GetTelemetryVarByIndex': illegal qualified name in member declaration
[\node_modules\@irsdk-node\native\build\irsdk_node.vcxproj]
\node_modules\@irsdk-node\native\src\irsdk_node.h(40,34): error        
C4596: 'GetTelemetryVar': illegal qualified name in member declaration
[\node_modules\@irsdk-node\native\build\irsdk_node.vcxproj]

1 Warning(s)
6 Error(s)
```