### PR TITLE
Fix typos, add analytics to documentation site

### DIFF
--- a/docs-site/docs/index.mdx
+++ b/docs-site/docs/index.mdx
@@ -116,6 +116,6 @@ While `irsdk-node` will provided baked-in optimisations for consuming iRacing da
 
 ### Full type access (`@irsdk-node/types`)
 
-All of the iRacing SDK types are also independently exposed to allow for building type-safe custom abstractions as well as accessing types in environments where the main libraries cannot be used, for example Electron renderer processes. The [@irsdk-node/types](https://www.npmjs.com/package/@irsdk-node/types) package is available for these use cases and offers all of the core typings, enums, and structures that `irsdk-node` provides while remaining completely environment agnostic.
+All of the iRacing SDK types are also independently exposed to allow for building type-safe custom abstractions as well as accessing types in environments where the main libraries cannot be used, for example Electron renderer processes. The [`@irsdk-node/types`](https://www.npmjs.com/package/@irsdk-node/types) package is available for these use cases and offers all of the core typings, enums, and structures that `irsdk-node` provides while remaining completely environment agnostic.
 
 [API Reference](./10-API-Reference/irsdk-node-types/README.md)

--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -86,6 +86,24 @@ const config: Config = {
             },
           ],
         },
+
+        {
+          title: 'Site analytics',
+          items: [
+            {
+              html: `
+<a href="https://librecounter.org/referer/show" class="footer__link-item libre-counter-link">
+  <img
+    src="https://librecounter.org/counter.svg"
+    referrerpolicy="unsafe-url"
+    alt="Logo for librecounter"
+    class="librecounter-logo"
+  /> via LibreCounter
+</a>
+`,
+            },
+          ],
+        }
       ],
 
       copyright: `Copyright © ${new Date().getFullYear()} bengsfort`,

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -28,3 +28,15 @@
   --ifm-color-primary-lightest: #4fddbf;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
+
+.librecounter-logo {
+  width: 24px;
+  height: 24px;
+}
+
+.libre-counter-link {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}


### PR DESCRIPTION
Updates the documentation site to fix some typos as well as add public analytics via [librecounter](https://librecounter.org).